### PR TITLE
Update README, remove some TODO items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ To do list:
 - [ ] invalid callsign detection, currently filtered by aprs-is servers
 - [X] convert telnet sandbox to socket(s)
 - [ ] lower latency  
-- [ ] duplicate detection and suppression with timer
-- [ ] binary inspection, handle all encodings
 
 
 Testing/QA:


### PR DESCRIPTION
Removed dupe filtering from the to-do list. A receive-only igate should not suppress duplicates, but rather leave it to the APRS-IS servers; they can utilize the duplicates too and this will give a more consistent implementation for the duplicate filtering. The duplicates can be extracted from the servers for network analysis, for example.
Removed "binary inspection", an iGate should pass the packet contents to the server as is, without making any special processing or de-encoding.