### PR TITLE
The reset_socket() method try may fail and still recoverable.

### DIFF
--- a/ygate.py
+++ b/ygate.py
@@ -81,7 +81,6 @@ def reset_socket():
   except Exception as e:
     print(">>> FAILED to close socket\n")
     print(e)
-    os._exit(1)  # If we can't do this, we're done!
 
 # Try to connect to aprs-is
 def connect_to_server():


### PR DESCRIPTION
In some cases, when remote server forces a disconnect, the socket is closed already.  Failing the try/catch in reset_socket() is not terminal and the state machine can successfully reconnect.

I've had my ygate running for just over two months 24/7.  This minor update increases robustness and allows for auto recovery of the only unrecoverable error I've seen in that time.